### PR TITLE
レスポンシブ対応

### DIFF
--- a/hikarie-lunch/app/components/ui/LoadingRippleAnimation.tsx
+++ b/hikarie-lunch/app/components/ui/LoadingRippleAnimation.tsx
@@ -1,0 +1,9 @@
+export const LoadingRippleAnimation = () => {
+    return <div className="flex justify-center items-center h-full">
+        <div className="flex justify-center" aria-label="読み込み中">
+            <div className="animate-ping h-2 w-2 bg-blue-600 rounded-full"></div>
+            <div className="animate-ping h-2 w-2 bg-blue-600 rounded-full mx-4"></div>
+            <div className="animate-ping h-2 w-2 bg-blue-600 rounded-full"></div>
+        </div>
+    </div>;
+}

--- a/hikarie-lunch/app/components/ui/LoadingRippleAnimation.tsx
+++ b/hikarie-lunch/app/components/ui/LoadingRippleAnimation.tsx
@@ -1,5 +1,5 @@
 export const LoadingRippleAnimation = () => {
-    return <div className="flex justify-center items-center h-full">
+    return <div className="flex justify-center items-center h-[calc(100vh-6rem)]">
         <div className="flex justify-center" aria-label="読み込み中">
             <div className="animate-ping h-2 w-2 bg-blue-600 rounded-full"></div>
             <div className="animate-ping h-2 w-2 bg-blue-600 rounded-full mx-4"></div>

--- a/hikarie-lunch/app/root.tsx
+++ b/hikarie-lunch/app/root.tsx
@@ -52,7 +52,6 @@ export default function App() {
       </head>
       <body>
         <div className="flex flex-col min-h-screen">
-          <Header />
           {/* PC版 */}
           {RestaurantListForWeb(restaurants)}
           {/* モバイル版 */}
@@ -65,7 +64,7 @@ export default function App() {
   );
 }
 
-const Header = () => {
+const HeaderForWeb = () => {
   return (
     <div className="h-24 px-4 pt-4 pb-2 bg-gray-800 text-white">
       <NavLink to="/">
@@ -73,7 +72,19 @@ const Header = () => {
       </NavLink>
       <div className="flex justify-between">
         <div className="text-xs">ヒカリエで働くひとのための、いい感じの飲食店がわかるサイト。</div>
-        {/* <div className="text-xs">このサービスについて</div> */}
+      </div>
+    </div>
+  );
+};
+
+const HeaderForMobile = () => {
+  return (
+    <div className="h-24 px-4 pt-4 pb-2 bg-gray-800 text-white">
+      <NavLink to="/">
+        <div className="text-4xl pb-2">Hikarie Workers Lunch</div>
+      </NavLink>
+      <div className="flex justify-between">
+        <div className="text-xs">ヒカリエで働くひとのための、いい感じの飲食店がわかるサイト。</div>
       </div>
     </div>
   );
@@ -83,26 +94,28 @@ const RestaurantList = ({ restaurants, setIsDetailFlag, className = "" }: { rest
   const [clickedRestaurantId, setClickedRestaurantId] = useState<string>("");
 
   return (
-    <div className={`${className} px-4 pt-4 pb-2 bg-red-100`}>
-      <ul>
-        {restaurants.map((restaurant) => (
-          <li key={restaurant.id}>
-            <NavLink
-              className={({ isActive, isPending }) =>
-                isActive
-                  ? "active"
-                  : isPending
-                    ? "pending"
-                    : ""
-              }
-              to={`detail/${restaurant.id}`}
-            >
-              <RestaurantCard restaurant={restaurant} isClicked={clickedRestaurantId === restaurant.id} setClickedRestaurantId={setClickedRestaurantId} setIsDetailFlag={setIsDetailFlag} />
-            </NavLink>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <>
+      <div className={`${className} px-4 pt-4 pb-2 bg-red-100`}>
+        <ul>
+          {restaurants.map((restaurant) => (
+            <li key={restaurant.id}>
+              <NavLink
+                className={({ isActive, isPending }) =>
+                  isActive
+                    ? "active"
+                    : isPending
+                      ? "pending"
+                      : ""
+                }
+                to={`detail/${restaurant.id}`}
+              >
+                <RestaurantCard restaurant={restaurant} isClicked={clickedRestaurantId === restaurant.id} setClickedRestaurantId={setClickedRestaurantId} setIsDetailFlag={setIsDetailFlag} />
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
   );
 }
 
@@ -171,30 +184,35 @@ const RestaurantCard = ({ restaurant, isClicked, setClickedRestaurantId, setIsDe
 };
 
 function RestaurantListForMobile(isDetailPage: boolean, setIsDetailFlag: React.Dispatch<React.SetStateAction<boolean>>, restaurants: ({ readonly id: string; readonly placeId: string; readonly displayName: string; readonly thumbnailPhotoUrl: string; readonly rating: number; readonly userRatingCount: number; readonly purposeLunch: boolean; readonly purposeDinner: boolean; readonly purposeCafe: boolean; readonly openingDays: { readonly monday: boolean; readonly tuesday: boolean; readonly wednesday: boolean; readonly thursday: boolean; readonly friday: boolean; readonly saturday: boolean; readonly sunday: boolean; } & {}; } & {})[]) {
-  return <div className="block xl:hidden">
-    <div className="flex flex-1 flex-col">
-      {isDetailPage ? (
-        <>
-          <div className="py-2 bg-blue-100">
-            <button onClick={() => setIsDetailFlag(false)}>
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" className="w-6 h-6">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-              </svg>
-            </button>
-          </div>
-          <div className="w-full h-[calc(100vh-6rem)] px-4 pb-4 bg-blue-100 overflow-y-auto">
-            <Outlet />
-          </div>
-        </>
-      ) : (
-        <RestaurantList restaurants={restaurants} setIsDetailFlag={setIsDetailFlag} className="w-full h-[calc(100vh-6rem)] overflow-y-auto" />
-      )}
-    </div>
-  </div>;
+  return (
+    <>
+      <div className="block xl:hidden">
+        <HeaderForMobile />
+        <div className="flex flex-1 flex-col">
+          {isDetailPage ? (
+            <>
+              <div className="py-2 bg-blue-100">
+                <button onClick={() => setIsDetailFlag(false)}>
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" className="w-6 h-6">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+                  </svg>
+                </button>
+              </div>
+              <div className="w-full h-[calc(100vh-6rem)] px-4 pb-4 bg-blue-100">
+                <Outlet />
+              </div>
+            </>
+          ) : (
+            <RestaurantList restaurants={restaurants} setIsDetailFlag={setIsDetailFlag} className="w-full h-[calc(100vh-6rem)]" />
+          )}
+        </div>
+      </div>
+    </>);
 }
 
 function RestaurantListForWeb(restaurants: ({ readonly id: string; readonly placeId: string; readonly displayName: string; readonly thumbnailPhotoUrl: string; readonly rating: number; readonly userRatingCount: number; readonly purposeLunch: boolean; readonly purposeDinner: boolean; readonly purposeCafe: boolean; readonly openingDays: { readonly monday: boolean; readonly tuesday: boolean; readonly wednesday: boolean; readonly thursday: boolean; readonly friday: boolean; readonly saturday: boolean; readonly sunday: boolean; } & {}; } & {})[]) {
   return <div className="hidden xl:block">
+    <HeaderForWeb />
     <div className="flex flex-1">
       <RestaurantList restaurants={restaurants} className="hidden xl:block xl:w-1/3 h-[calc(100vh-6rem)] overflow-y-auto" />
       <div className="w-full xl:w-2/3 h-[calc(100vh-6rem)] px-4 py-4 bg-blue-100 overflow-y-auto">

--- a/hikarie-lunch/app/root.tsx
+++ b/hikarie-lunch/app/root.tsx
@@ -54,35 +54,9 @@ export default function App() {
         <div className="flex flex-col min-h-screen">
           <Header />
           {/* PC版 */}
-          <div className="hidden xl:block">
-            <div className="flex flex-1">
-              <RestaurantList restaurants={restaurants} className="hidden xl:block xl:w-1/3 h-[calc(100vh-6rem)] overflow-y-auto" />
-              <div className="w-full xl:w-2/3 h-[calc(100vh-6rem)] px-4 py-4 bg-blue-100 overflow-y-auto">
-                <Outlet />
-              </div>
-            </div>
-          </div>
+          {RestaurantListForWeb(restaurants)}
           {/* モバイル版 */}
-          <div className="block xl:hidden">
-            <div className="flex flex-1 flex-col">
-              {isDetailPage ? (
-                <>
-                  <div className="py-2 bg-blue-100">
-                    <button onClick={() => setIsDetailFlag(false)}>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" className="w-6 h-6">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-                      </svg>
-                    </button>
-                  </div>
-                  <div className="w-full h-[calc(100vh-6rem)] px-4 pb-4 bg-blue-100 overflow-y-auto">
-                    <Outlet />
-                  </div>
-                </>
-              ) : (
-                <RestaurantList restaurants={restaurants} setIsDetailFlag={setIsDetailFlag} className="w-full h-[calc(100vh-6rem)] overflow-y-auto" />
-              )}
-            </div>
-          </div>
+          {RestaurantListForMobile(isDetailPage, setIsDetailFlag, restaurants)}
         </div>
         <ScrollRestoration />
         <Scripts />
@@ -195,4 +169,38 @@ const RestaurantCard = ({ restaurant, isClicked, setClickedRestaurantId, setIsDe
     </div>
   );
 };
+
+function RestaurantListForMobile(isDetailPage: boolean, setIsDetailFlag: React.Dispatch<React.SetStateAction<boolean>>, restaurants: ({ readonly id: string; readonly placeId: string; readonly displayName: string; readonly thumbnailPhotoUrl: string; readonly rating: number; readonly userRatingCount: number; readonly purposeLunch: boolean; readonly purposeDinner: boolean; readonly purposeCafe: boolean; readonly openingDays: { readonly monday: boolean; readonly tuesday: boolean; readonly wednesday: boolean; readonly thursday: boolean; readonly friday: boolean; readonly saturday: boolean; readonly sunday: boolean; } & {}; } & {})[]) {
+  return <div className="block xl:hidden">
+    <div className="flex flex-1 flex-col">
+      {isDetailPage ? (
+        <>
+          <div className="py-2 bg-blue-100">
+            <button onClick={() => setIsDetailFlag(false)}>
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" className="w-6 h-6">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+              </svg>
+            </button>
+          </div>
+          <div className="w-full h-[calc(100vh-6rem)] px-4 pb-4 bg-blue-100 overflow-y-auto">
+            <Outlet />
+          </div>
+        </>
+      ) : (
+        <RestaurantList restaurants={restaurants} setIsDetailFlag={setIsDetailFlag} className="w-full h-[calc(100vh-6rem)] overflow-y-auto" />
+      )}
+    </div>
+  </div>;
+}
+
+function RestaurantListForWeb(restaurants: ({ readonly id: string; readonly placeId: string; readonly displayName: string; readonly thumbnailPhotoUrl: string; readonly rating: number; readonly userRatingCount: number; readonly purposeLunch: boolean; readonly purposeDinner: boolean; readonly purposeCafe: boolean; readonly openingDays: { readonly monday: boolean; readonly tuesday: boolean; readonly wednesday: boolean; readonly thursday: boolean; readonly friday: boolean; readonly saturday: boolean; readonly sunday: boolean; } & {}; } & {})[]) {
+  return <div className="hidden xl:block">
+    <div className="flex flex-1">
+      <RestaurantList restaurants={restaurants} className="hidden xl:block xl:w-1/3 h-[calc(100vh-6rem)] overflow-y-auto" />
+      <div className="w-full xl:w-2/3 h-[calc(100vh-6rem)] px-4 py-4 bg-blue-100 overflow-y-auto">
+        <Outlet />
+      </div>
+    </div>
+  </div>;
+}
 

--- a/hikarie-lunch/app/root.tsx
+++ b/hikarie-lunch/app/root.tsx
@@ -51,9 +51,9 @@ export default function App() {
       <body>
         <div className="flex flex-col h-screen">
           <Header />
-          <div className="flex">
-            <RestaurantList restaurants={restaurants} className="hidden xl:block xl:w-1/3" />
-            <div className="w-full xl:w-2/3 h-screen px-4 py-4 bg-blue-100 overflow-y-auto">
+          <div className="flex h-[89%]">
+            <RestaurantList restaurants={restaurants} className="hidden xl:block xl:w-1/3 overflow-y-auto" />
+            <div className="w-full xl:w-2/3 px-4 py-4 bg-blue-100 overflow-y-auto">
               <Outlet />
             </div>
           </div>
@@ -67,7 +67,7 @@ export default function App() {
 
 const Header = () => {
   return (
-    <div className="px-4 pt-4 pb-2 bg-gray-800 text-white">
+    <div className="h-[11%] px-4 pt-4 pb-2 bg-gray-800 text-white">
       <NavLink to="/">
         <div className="text-4xl pb-2">Hikarie Workers Lunch</div>
       </NavLink>
@@ -83,7 +83,7 @@ const RestaurantList = ({ restaurants, className = "" }: { restaurants: Restaura
   const [clickedRestaurantId, setClickedRestaurantId] = useState<string>("");
 
   return (
-    <div className={`${className} h-screen px-4 pt-4 pb-2 bg-red-100 overflow-y-auto`}>
+    <div className={`${className} px-4 pt-4 pb-2 bg-red-100`}>
       <div className="text-2xl pb-2">飲食店一覧</div>
       <ul>
         {restaurants.map((restaurant) => (

--- a/hikarie-lunch/app/root.tsx
+++ b/hikarie-lunch/app/root.tsx
@@ -49,11 +49,11 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <div className="flex flex-col h-screen">
+        <div className="flex flex-col min-h-screen">
           <Header />
-          <div className="flex h-[89%]">
-            <RestaurantList restaurants={restaurants} className="hidden xl:block xl:w-1/3 overflow-y-auto" />
-            <div className="w-full xl:w-2/3 px-4 py-4 bg-blue-100 overflow-y-auto">
+          <div className="flex flex-1">
+            <RestaurantList restaurants={restaurants} className="hidden xl:block xl:w-1/3 h-[calc(100vh-6rem)] overflow-y-auto" />
+            <div className="w-full xl:w-2/3 h-[calc(100vh-6rem)] px-4 py-4 bg-blue-100 overflow-y-auto">
               <Outlet />
             </div>
           </div>
@@ -67,7 +67,7 @@ export default function App() {
 
 const Header = () => {
   return (
-    <div className="h-[11%] px-4 pt-4 pb-2 bg-gray-800 text-white">
+    <div className="h-24 px-4 pt-4 pb-2 bg-gray-800 text-white">
       <NavLink to="/">
         <div className="text-4xl pb-2">Hikarie Workers Lunch</div>
       </NavLink>

--- a/hikarie-lunch/app/root.tsx
+++ b/hikarie-lunch/app/root.tsx
@@ -49,11 +49,11 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <div className="flex flex-col">
+        <div className="flex flex-col h-screen">
           <Header />
-          <div className="flex justify-between">
-            <RestaurantList restaurants={restaurants} />
-            <div className="w-2/3 h-screen px-4 py-4 bg-blue-100 overflow-y-auto">
+          <div className="flex">
+            <RestaurantList restaurants={restaurants} className="hidden xl:block xl:w-1/3" />
+            <div className="w-full xl:w-2/3 h-screen px-4 py-4 bg-blue-100 overflow-y-auto">
               <Outlet />
             </div>
           </div>
@@ -79,11 +79,11 @@ const Header = () => {
   );
 };
 
-const RestaurantList = ({ restaurants }: { restaurants: RestaurantForList[] }) => {
+const RestaurantList = ({ restaurants, className = "" }: { restaurants: RestaurantForList[], className?: string }) => {
   const [clickedRestaurantId, setClickedRestaurantId] = useState<string>("");
 
   return (
-    <div className="w-1/3 h-screen px-4 pt-4 pb-2 bg-red-100 overflow-y-auto">
+    <div className={`${className} h-screen px-4 pt-4 pb-2 bg-red-100 overflow-y-auto`}>
       <div className="text-2xl pb-2">飲食店一覧</div>
       <ul>
         {restaurants.map((restaurant) => (

--- a/hikarie-lunch/app/root.tsx
+++ b/hikarie-lunch/app/root.tsx
@@ -40,6 +40,8 @@ export const loader = async ({ context }: LoaderFunctionArgs) => {
 
 export default function App() {
   const { restaurants } = useLoaderData<typeof loader>();
+  const [isDetailPage, setIsDetailFlag] = useState<boolean>(false);
+
   return (
     <html lang="ja">
       <head>
@@ -51,17 +53,41 @@ export default function App() {
       <body>
         <div className="flex flex-col min-h-screen">
           <Header />
-          <div className="flex flex-1">
-            <RestaurantList restaurants={restaurants} className="hidden xl:block xl:w-1/3 h-[calc(100vh-6rem)] overflow-y-auto" />
-            <div className="w-full xl:w-2/3 h-[calc(100vh-6rem)] px-4 py-4 bg-blue-100 overflow-y-auto">
-              <Outlet />
+          {/* PC版 */}
+          <div className="hidden xl:block">
+            <div className="flex flex-1">
+              <RestaurantList restaurants={restaurants} className="hidden xl:block xl:w-1/3 h-[calc(100vh-6rem)] overflow-y-auto" />
+              <div className="w-full xl:w-2/3 h-[calc(100vh-6rem)] px-4 py-4 bg-blue-100 overflow-y-auto">
+                <Outlet />
+              </div>
+            </div>
+          </div>
+          {/* モバイル版 */}
+          <div className="block xl:hidden">
+            <div className="flex flex-1 flex-col">
+              {isDetailPage ? (
+                <>
+                  <div className="py-2 bg-blue-100">
+                    <button onClick={() => setIsDetailFlag(false)}>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor" className="w-6 h-6">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+                      </svg>
+                    </button>
+                  </div>
+                  <div className="w-full h-[calc(100vh-6rem)] px-4 pb-4 bg-blue-100 overflow-y-auto">
+                    <Outlet />
+                  </div>
+                </>
+              ) : (
+                <RestaurantList restaurants={restaurants} setIsDetailFlag={setIsDetailFlag} className="w-full h-[calc(100vh-6rem)] overflow-y-auto" />
+              )}
             </div>
           </div>
         </div>
         <ScrollRestoration />
         <Scripts />
       </body>
-    </html>
+    </html >
   );
 }
 
@@ -79,7 +105,7 @@ const Header = () => {
   );
 };
 
-const RestaurantList = ({ restaurants, className = "" }: { restaurants: RestaurantForList[], className?: string }) => {
+const RestaurantList = ({ restaurants, setIsDetailFlag, className = "" }: { restaurants: RestaurantForList[], setIsDetailFlag?: React.Dispatch<React.SetStateAction<boolean>>, className?: string }) => {
   const [clickedRestaurantId, setClickedRestaurantId] = useState<string>("");
 
   return (
@@ -97,7 +123,7 @@ const RestaurantList = ({ restaurants, className = "" }: { restaurants: Restaura
               }
               to={`detail/${restaurant.id}`}
             >
-              <RestaurantCard restaurant={restaurant} isClicked={clickedRestaurantId === restaurant.id} setClickedRestaurantId={setClickedRestaurantId} />
+              <RestaurantCard restaurant={restaurant} isClicked={clickedRestaurantId === restaurant.id} setClickedRestaurantId={setClickedRestaurantId} setIsDetailFlag={setIsDetailFlag} />
             </NavLink>
           </li>
         ))}
@@ -111,12 +137,16 @@ interface RestaurantCardProps {
   restaurant: RestaurantForList;
   isClicked: boolean;
   setClickedRestaurantId: React.Dispatch<React.SetStateAction<string>>;
+  setIsDetailFlag?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const RestaurantCard = ({ restaurant, isClicked, setClickedRestaurantId }: RestaurantCardProps) => {
+const RestaurantCard = ({ restaurant, isClicked, setClickedRestaurantId, setIsDetailFlag }: RestaurantCardProps) => {
 
   const handleClick = () => {
     setClickedRestaurantId(restaurant.id);
+    if (setIsDetailFlag !== undefined) {
+      setIsDetailFlag(true);
+    }
   }
 
   const cardStyle = `${isClicked ? "bg-[#F1E3A8]" : "bg-[#FFF8F6] cursor-pointer"} p-4 mb-2 rounded-lg shadow-md border border-black" : "p-4 mb-2 rounded-lg shadow-md border border-black"`;

--- a/hikarie-lunch/app/root.tsx
+++ b/hikarie-lunch/app/root.tsx
@@ -84,7 +84,6 @@ const RestaurantList = ({ restaurants, className = "" }: { restaurants: Restaura
 
   return (
     <div className={`${className} px-4 pt-4 pb-2 bg-red-100`}>
-      <div className="text-2xl pb-2">飲食店一覧</div>
       <ul>
         {restaurants.map((restaurant) => (
           <li key={restaurant.id}>

--- a/hikarie-lunch/app/root.tsx
+++ b/hikarie-lunch/app/root.tsx
@@ -6,6 +6,7 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
+  useNavigation,
 } from "@remix-run/react";
 import { json, LoaderFunctionArgs, type MetaFunction } from "@remix-run/cloudflare";
 
@@ -15,6 +16,7 @@ import { RestaurantForList } from "./entity/Restaurant";
 import { Bubble, StarRatingComponent } from "./components/ui/components";
 import { formatNumberWithCommas } from "./utils/utils";
 import { useState } from "react";
+import { LoadingRippleAnimation } from "./components/ui/LoadingRippleAnimation";
 
 export const meta: MetaFunction = () => {
   return [
@@ -183,9 +185,12 @@ const RestaurantCard = ({ restaurant, isClicked, setClickedRestaurantId, setIsDe
   );
 };
 
-function RestaurantListForMobile(isDetailPage: boolean, setIsDetailFlag: React.Dispatch<React.SetStateAction<boolean>>, restaurants: ({ readonly id: string; readonly placeId: string; readonly displayName: string; readonly thumbnailPhotoUrl: string; readonly rating: number; readonly userRatingCount: number; readonly purposeLunch: boolean; readonly purposeDinner: boolean; readonly purposeCafe: boolean; readonly openingDays: { readonly monday: boolean; readonly tuesday: boolean; readonly wednesday: boolean; readonly thursday: boolean; readonly friday: boolean; readonly saturday: boolean; readonly sunday: boolean; } & {}; } & {})[]) {
+const RestaurantListForMobile = (isDetailPage: boolean, setIsDetailFlag: React.Dispatch<React.SetStateAction<boolean>>, restaurants: ({ readonly id: string; readonly placeId: string; readonly displayName: string; readonly thumbnailPhotoUrl: string; readonly rating: number; readonly userRatingCount: number; readonly purposeLunch: boolean; readonly purposeDinner: boolean; readonly purposeCafe: boolean; readonly openingDays: { readonly monday: boolean; readonly tuesday: boolean; readonly wednesday: boolean; readonly thursday: boolean; readonly friday: boolean; readonly saturday: boolean; readonly sunday: boolean; } & {}; } & {})[]) => {
+  const navigation = useNavigation();
+
   return (
     <>
+
       <div className="block xl:hidden">
         <HeaderForMobile />
         <div className="flex flex-1 flex-col">
@@ -199,26 +204,38 @@ function RestaurantListForMobile(isDetailPage: boolean, setIsDetailFlag: React.D
                 </button>
               </div>
               <div className="w-full h-[calc(100vh-6rem)] px-4 pb-4 bg-blue-100">
-                <Outlet />
+                {
+                  navigation.state === "loading" ?
+                    <LoadingRippleAnimation /> : <Outlet />
+                }
               </div>
             </>
           ) : (
             <RestaurantList restaurants={restaurants} setIsDetailFlag={setIsDetailFlag} className="w-full h-[calc(100vh-6rem)]" />
           )}
+
         </div>
       </div>
     </>);
 }
 
-function RestaurantListForWeb(restaurants: ({ readonly id: string; readonly placeId: string; readonly displayName: string; readonly thumbnailPhotoUrl: string; readonly rating: number; readonly userRatingCount: number; readonly purposeLunch: boolean; readonly purposeDinner: boolean; readonly purposeCafe: boolean; readonly openingDays: { readonly monday: boolean; readonly tuesday: boolean; readonly wednesday: boolean; readonly thursday: boolean; readonly friday: boolean; readonly saturday: boolean; readonly sunday: boolean; } & {}; } & {})[]) {
-  return <div className="hidden xl:block">
-    <HeaderForWeb />
-    <div className="flex flex-1">
-      <RestaurantList restaurants={restaurants} className="hidden xl:block xl:w-1/3 h-[calc(100vh-6rem)] overflow-y-auto" />
-      <div className="w-full xl:w-2/3 h-[calc(100vh-6rem)] px-4 py-4 bg-blue-100 overflow-y-auto">
-        <Outlet />
+const RestaurantListForWeb = (restaurants: ({ readonly id: string; readonly placeId: string; readonly displayName: string; readonly thumbnailPhotoUrl: string; readonly rating: number; readonly userRatingCount: number; readonly purposeLunch: boolean; readonly purposeDinner: boolean; readonly purposeCafe: boolean; readonly openingDays: { readonly monday: boolean; readonly tuesday: boolean; readonly wednesday: boolean; readonly thursday: boolean; readonly friday: boolean; readonly saturday: boolean; readonly sunday: boolean; } & {}; } & {})[]) => {
+  const navigation = useNavigation();
+
+  return (
+
+    <div className="hidden xl:block">
+      <HeaderForWeb />
+      <div className="flex flex-1">
+        <RestaurantList restaurants={restaurants} className="hidden xl:block xl:w-1/3 h-[calc(100vh-6rem)] overflow-y-auto" />
+        <div className="w-full xl:w-2/3 h-[calc(100vh-6rem)] px-4 py-4 bg-blue-100 overflow-y-auto">
+          {
+            navigation.state === "loading" ?
+              <LoadingRippleAnimation /> : <Outlet />
+          }
+        </div>
       </div>
     </div>
-  </div>;
+  );
 }
 

--- a/hikarie-lunch/app/root.tsx
+++ b/hikarie-lunch/app/root.tsx
@@ -203,15 +203,17 @@ const RestaurantListForMobile = (isDetailPage: boolean, setIsDetailFlag: React.D
                   </svg>
                 </button>
               </div>
-              <div className="w-full h-[calc(100vh-6rem)] px-4 pb-4 bg-blue-100">
+              <div className="w-full h-full px-4 pb-4 bg-blue-100">
                 {
                   navigation.state === "loading" ?
-                    <LoadingRippleAnimation /> : <Outlet />
+                    <LoadingRippleAnimation />
+                    :
+                    <Outlet />
                 }
               </div>
             </>
           ) : (
-            <RestaurantList restaurants={restaurants} setIsDetailFlag={setIsDetailFlag} className="w-full h-[calc(100vh-6rem)]" />
+            <RestaurantList restaurants={restaurants} setIsDetailFlag={setIsDetailFlag} className="w-full h-full" />
           )}
 
         </div>

--- a/hikarie-lunch/app/routes/detail.$restaurantId.tsx
+++ b/hikarie-lunch/app/routes/detail.$restaurantId.tsx
@@ -26,7 +26,7 @@ export const loader = async ({ params, context }: LoaderFunctionArgs) => {
 export default function RestaurantDetail() {
     const { detail } = useLoaderData<typeof loader>();
     return (
-        <div className="max-w-4xl mx-auto bg-[#FFF8F6] shadow-lg rounded-lg overflow-hidden h-screen overflow-y-auto">
+        <div className="max-w-4xl mx-auto bg-[#FFF8F6] shadow-lg rounded-lg">
             <div className="p-4">
                 <div className="flex items-center mb-2">
                     <h1 className="text-2xl font-bold">{detail.displayName}</h1>

--- a/hikarie-lunch/app/routes/detail.$restaurantId.tsx
+++ b/hikarie-lunch/app/routes/detail.$restaurantId.tsx
@@ -4,7 +4,6 @@ import { OpeningHour, PriceLevel, RestaurantForDetail } from "~/entity/Restauran
 import { formatNumberWithCommas } from "~/utils/utils";
 import { json, LoaderFunctionArgs } from "@remix-run/cloudflare";
 import invariant from "tiny-invariant";
-// import { ClientOnly } from "remix-utils/client-only";
 
 export const loader = async ({ params, context }: LoaderFunctionArgs) => {
     invariant(params.restaurantId, "Missing restaurantId param");
@@ -53,7 +52,7 @@ export default function RestaurantDetail() {
                     <span>カフェ {detail.purposeCafe ? "○" : "-"}</span>
                 </div>
 
-                <div className="grid grid-cols-1 md:grid-cols-4 gap-2 mb-4">
+                <div className="grid grid-cols-3 md:grid-cols-4 gap-2 mb-4">
                     <div className="md:col-span-2 md:row-span-2 aspect-[4/3]">
                         <img src={detail.photoUrls[0]} alt="Main" className="w-full h-full object-cover rounded" />
                     </div>
@@ -68,6 +67,9 @@ export default function RestaurantDetail() {
                     </div>
                     <div className="aspect-[4/3]">
                         <img src={detail.photoUrls[4]} alt="Sub 4" className="w-full h-full object-cover rounded" />
+                    </div>
+                    <div className="aspect-[4/3] md:hidden">
+                        <img src={detail.photoUrls[5]} alt="Sub 5" className="w-full h-full object-cover rounded" />
                     </div>
                 </div>
 
@@ -114,10 +116,6 @@ export default function RestaurantDetail() {
                             </tbody>
                         </table>
                     </div>
-
-                    {/* <ClientOnly fallback={<div>Loading</div>}>
-                        {() => <GoogleMapComponent />}
-                    </ClientOnly> */}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
# 対応内容
- モバイルまたはブラウザサイズが小さい場合に一覧画面のみを表示し、カードをクリックすると詳細画面へ遷移できるように変更。
  - 一覧画面へ戻るボタンも実装

# 残タスク
- [ ] ブラウザバック時に一覧ではなく前の詳細に遷移する問題の対応
    - いい方法が思いつかないので対応見送り
- [x] 画像サイズが大きすぎるので調整
- [x] タイトルはスクロールされるようにする